### PR TITLE
Move FBX data without retaining a copy of it

### DIFF
--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -77,7 +77,7 @@ void ScriptableAvatar::update(float deltatime) {
                 const QString& name = animationJointNames[i];
                 // As long as we need the model preRotations anyway, let's get the jointIndex from the bind skeleton rather than
                 // trusting the .fst (which is sometimes not updated to match changes to .fbx).
-                int mapping = _bind->getGeometry().getJointIndex(name);
+                int mapping = _bind->getGeometry().joints.getJointIndex(name);
                 if (mapping != -1 && !_maskedJoints.contains(name)) {
                     JointData& data = _jointData[mapping];
 

--- a/assignment-client/src/avatars/ScriptableAvatar.cpp
+++ b/assignment-client/src/avatars/ScriptableAvatar.cpp
@@ -61,8 +61,8 @@ void ScriptableAvatar::update(float deltatime) {
             }
             _animationDetails.currentFrame = currentFrame;
 
-            const QVector<FBXJoint>& modelJoints = _bind->getGeometry().joints;
-            QStringList animationJointNames = _animation->getJointNames();
+            const auto& modelJoints = _bind->getJoints();
+            auto animationJointNames = _animation->getJointNames();
 
             if (_jointData.size() != modelJoints.size()) {
                 _jointData.resize(modelJoints.size());
@@ -77,7 +77,7 @@ void ScriptableAvatar::update(float deltatime) {
                 const QString& name = animationJointNames[i];
                 // As long as we need the model preRotations anyway, let's get the jointIndex from the bind skeleton rather than
                 // trusting the .fst (which is sometimes not updated to match changes to .fbx).
-                int mapping = _bind->getGeometry().joints.getJointIndex(name);
+                int mapping = _bind->getJoints().getJointIndex(name);
                 if (mapping != -1 && !_maskedJoints.contains(name)) {
                     JointData& data = _jointData[mapping];
 

--- a/interface/src/ModelPackager.cpp
+++ b/interface/src/ModelPackager.cpp
@@ -244,15 +244,15 @@ void ModelPackager::populateBasicMapping(QVariantHash& mapping, QString filename
     }
     QVariantHash joints = mapping.value(JOINT_FIELD).toHash();
     if (!joints.contains("jointEyeLeft")) {
-        joints.insert("jointEyeLeft", geometry.jointIndices.contains("jointEyeLeft") ? "jointEyeLeft" :
-                      (geometry.jointIndices.contains("EyeLeft") ? "EyeLeft" : "LeftEye"));
+        joints.insert("jointEyeLeft", geometry.joints.indices.contains("jointEyeLeft") ? "jointEyeLeft" :
+                      (geometry.joints.indices.contains("EyeLeft") ? "EyeLeft" : "LeftEye"));
     }
     if (!joints.contains("jointEyeRight")) {
-        joints.insert("jointEyeRight", geometry.jointIndices.contains("jointEyeRight") ? "jointEyeRight" :
-                      geometry.jointIndices.contains("EyeRight") ? "EyeRight" : "RightEye");
+        joints.insert("jointEyeRight", geometry.joints.indices.contains("jointEyeRight") ? "jointEyeRight" :
+                      geometry.joints.indices.contains("EyeRight") ? "EyeRight" : "RightEye");
     }
     if (!joints.contains("jointNeck")) {
-        joints.insert("jointNeck", geometry.jointIndices.contains("jointNeck") ? "jointNeck" : "Neck");
+        joints.insert("jointNeck", geometry.joints.indices.contains("jointNeck") ? "jointNeck" : "Neck");
     }
     
     if (isBodyType) {
@@ -272,7 +272,7 @@ void ModelPackager::populateBasicMapping(QVariantHash& mapping, QString filename
     
     if (!joints.contains("jointHead")) {
         const char* topName = likelyMixamoFile ? "HeadTop_End" : "HeadEnd";
-        joints.insert("jointHead", geometry.jointIndices.contains(topName) ? topName : "Head");
+        joints.insert("jointHead", geometry.joints.indices.contains(topName) ? topName : "Head");
     }
 
     mapping.insert(JOINT_FIELD, joints);

--- a/interface/src/ModelPropertiesDialog.cpp
+++ b/interface/src/ModelPropertiesDialog.cpp
@@ -114,7 +114,7 @@ QVariantHash ModelPropertiesDialog::getMapping() const {
         if (_modelType == FSTReader::ATTACHMENT_MODEL) {
             glm::vec3 pivot;
             if (_pivotAboutCenter->isChecked()) {
-                pivot = (_geometry.meshExtents.minimum + _geometry.meshExtents.maximum) * 0.5f;
+                pivot = (_geometry.meshes.meshExtents.minimum + _geometry.meshes.meshExtents.maximum) * 0.5f;
 
             } else if (_pivotJoint->currentIndex() != 0) {
                 pivot = extractTranslation(_geometry.joints.at(_pivotJoint->currentIndex() - 1).transform);
@@ -186,7 +186,7 @@ void ModelPropertiesDialog::reset() {
             }
             foreach (const QVariant& joint, _originalMapping.values(FREE_JOINT_FIELD)) {
                 QString jointName = joint.toString();
-                if (_geometry.jointIndices.contains(jointName)) {
+                if (_geometry.joints.indices.contains(jointName)) {
                     createNewFreeJoint(jointName);
                 }
             }
@@ -231,7 +231,7 @@ QComboBox* ModelPropertiesDialog::createJointBox(bool withNone) const {
         box->addItem("(none)");
     }
     foreach (const FBXJoint& joint, _geometry.joints) {
-        if (joint.isSkeletonJoint || !_geometry.hasSkeletonJoints) {
+        if (joint.isSkeletonJoint || !_geometry.joints.hasSkeletonJoints()) {
             box->addItem(joint.name);
         }
     }
@@ -247,7 +247,7 @@ QDoubleSpinBox* ModelPropertiesDialog::createTranslationBox() const {
 }
 
 void ModelPropertiesDialog::insertJointMapping(QVariantHash& joints, const QString& joint, const QString& name) const {
-    if (_geometry.jointIndices.contains(name)) {
+    if (_geometry.joints.indices.contains(name)) {
         joints.insert(joint, name);
     } else {
         joints.remove(joint);

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -467,7 +467,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                 / (LOOKING_AT_ME_DURATION * (float)USECS_PER_SECOND));
             if (alpha > 0.0f) {
                 if (_skeletonModel->isLoaded()) {
-                    const auto& geometry = _skeletonModel->getFBXGeometry();
+                    const auto& meshes = _skeletonModel->getGeometry()->getMeshes();
                     const float DEFAULT_EYE_DIAMETER = 0.048f;  // Typical human eye
                     const float RADIUS_INCREMENT = 0.005f;
                     batch.setModelTransform(Transform());
@@ -475,7 +475,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                     glm::vec3 position = getHead()->getLeftEyePosition();
                     Transform transform;
                     transform.setTranslation(position);
-                    float eyeDiameter = geometry.meshes.leftEyeSize;
+                    float eyeDiameter = meshes.leftEyeSize;
                     if (eyeDiameter == 0.0f) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
@@ -486,7 +486,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
 
                     position = getHead()->getRightEyePosition();
                     transform.setTranslation(position);
-                    eyeDiameter = geometry.meshes.rightEyeSize;
+                    eyeDiameter = meshes.rightEyeSize;
                     if (eyeDiameter == 0.0f) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
@@ -815,7 +815,7 @@ int Avatar::getJointIndex(const QString& name) const {
             Q_RETURN_ARG(int, result), Q_ARG(const QString&, name));
         return result;
     }
-    return _skeletonModel->isActive() ? _skeletonModel->getFBXGeometry().joints.getJointIndex(name) : -1;
+    return _skeletonModel->isActive() ? _skeletonModel->getGeometry()->getJoints().getJointIndex(name) : -1;
 }
 
 QStringList Avatar::getJointNames() const {
@@ -825,7 +825,7 @@ QStringList Avatar::getJointNames() const {
             Q_RETURN_ARG(QStringList, result));
         return result;
     }
-    return _skeletonModel->isActive() ? _skeletonModel->getFBXGeometry().joints.getJointNames() : QStringList();
+    return _skeletonModel->isActive() ? _skeletonModel->getGeometry()->getJoints().getJointNames() : QStringList();
 }
 
 glm::vec3 Avatar::getJointPosition(int index) const {

--- a/interface/src/avatar/Avatar.cpp
+++ b/interface/src/avatar/Avatar.cpp
@@ -475,7 +475,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
                     glm::vec3 position = getHead()->getLeftEyePosition();
                     Transform transform;
                     transform.setTranslation(position);
-                    float eyeDiameter = geometry.leftEyeSize;
+                    float eyeDiameter = geometry.meshes.leftEyeSize;
                     if (eyeDiameter == 0.0f) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
@@ -486,7 +486,7 @@ void Avatar::render(RenderArgs* renderArgs, const glm::vec3& cameraPosition) {
 
                     position = getHead()->getRightEyePosition();
                     transform.setTranslation(position);
-                    eyeDiameter = geometry.rightEyeSize;
+                    eyeDiameter = geometry.meshes.rightEyeSize;
                     if (eyeDiameter == 0.0f) {
                         eyeDiameter = DEFAULT_EYE_DIAMETER;
                     }
@@ -815,7 +815,7 @@ int Avatar::getJointIndex(const QString& name) const {
             Q_RETURN_ARG(int, result), Q_ARG(const QString&, name));
         return result;
     }
-    return _skeletonModel->isActive() ? _skeletonModel->getFBXGeometry().getJointIndex(name) : -1;
+    return _skeletonModel->isActive() ? _skeletonModel->getFBXGeometry().joints.getJointIndex(name) : -1;
 }
 
 QStringList Avatar::getJointNames() const {
@@ -825,7 +825,7 @@ QStringList Avatar::getJointNames() const {
             Q_RETURN_ARG(QStringList, result));
         return result;
     }
-    return _skeletonModel->isActive() ? _skeletonModel->getFBXGeometry().getJointNames() : QStringList();
+    return _skeletonModel->isActive() ? _skeletonModel->getFBXGeometry().joints.getJointNames() : QStringList();
 }
 
 glm::vec3 Avatar::getJointPosition(int index) const {

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1275,7 +1275,7 @@ void MyAvatar::setVisibleInSceneIfReady(Model* model, render::ScenePointer scene
 void MyAvatar::initHeadBones() {
     int neckJointIndex = -1;
     if (_skeletonModel->isLoaded()) {
-        neckJointIndex = _skeletonModel->getFBXGeometry().neckJointIndex;
+        neckJointIndex = _skeletonModel->getFBXGeometry().joints.neckJointIndex;
     }
     if (neckJointIndex == -1) {
         return;

--- a/interface/src/avatar/MyAvatar.cpp
+++ b/interface/src/avatar/MyAvatar.cpp
@@ -1275,7 +1275,7 @@ void MyAvatar::setVisibleInSceneIfReady(Model* model, render::ScenePointer scene
 void MyAvatar::initHeadBones() {
     int neckJointIndex = -1;
     if (_skeletonModel->isLoaded()) {
-        neckJointIndex = _skeletonModel->getFBXGeometry().joints.neckJointIndex;
+        neckJointIndex = _skeletonModel->getGeometry()->getJoints().neckJointIndex;
     }
     if (neckJointIndex == -1) {
         return;

--- a/interface/src/avatar/SkeletonModel.cpp
+++ b/interface/src/avatar/SkeletonModel.cpp
@@ -39,12 +39,12 @@ SkeletonModel::~SkeletonModel() {
 }
 
 void SkeletonModel::initJointStates() {
-    const FBXGeometry& geometry = getFBXGeometry();
+    const auto& joints = getGeometry()->getJoints();
     glm::mat4 modelOffset = glm::scale(_scale) * glm::translate(_offset);
-    _rig->initJointStates(geometry.joints, modelOffset);
+    _rig->initJointStates(joints, modelOffset);
 
     // Determine the default eye position for avatar scale = 1.0
-    int headJointIndex = geometry.joints.headJointIndex;
+    int headJointIndex = joints.headJointIndex;
     if (0 > headJointIndex || headJointIndex >= _rig->getJointStateCount()) {
         qCWarning(interfaceapp) << "Bad head joint! Got:" << headJointIndex << "jointCount:" << _rig->getJointStateCount();
     }
@@ -52,7 +52,7 @@ void SkeletonModel::initJointStates() {
     getEyeModelPositions(leftEyePosition, rightEyePosition);
     glm::vec3 midEyePosition = (leftEyePosition + rightEyePosition) / 2.0f;
 
-    int rootJointIndex = geometry.joints.rootJointIndex;
+    int rootJointIndex = joints.rootJointIndex;
     glm::vec3 rootModelPosition;
     getJointPosition(rootJointIndex, rootModelPosition);
 
@@ -87,7 +87,7 @@ Rig::CharacterControllerState convertCharacterControllerState(CharacterControlle
 
 // Called within Model::simulate call, below.
 void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
-    const FBXGeometry& geometry = getFBXGeometry();
+    const auto& joints = getGeometry()->getJoints();
 
     Head* head = _owningAvatar->getHead();
 
@@ -120,8 +120,8 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
             headParams.worldHeadOrientation = head->getFinalOrientationInWorldFrame();
         }
 
-        headParams.leanJointIndex = geometry.joints.leanJointIndex;
-        headParams.neckJointIndex = geometry.joints.neckJointIndex;
+        headParams.leanJointIndex = joints.leanJointIndex;
+        headParams.neckJointIndex = joints.neckJointIndex;
         headParams.isTalking = head->getTimeWithoutTalking() <= 1.5f;
 
         _rig->updateFromHeadParameters(headParams, deltaTime);
@@ -168,8 +168,8 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
         eyeParams.eyeSaccade = head->getSaccade();
         eyeParams.modelRotation = getRotation();
         eyeParams.modelTranslation = getTranslation();
-        eyeParams.leftEyeJointIndex = geometry.joints.leftEyeJointIndex;
-        eyeParams.rightEyeJointIndex = geometry.joints.rightEyeJointIndex;
+        eyeParams.leftEyeJointIndex = joints.leftEyeJointIndex;
+        eyeParams.rightEyeJointIndex = joints.rightEyeJointIndex;
 
         _rig->updateFromEyeParameters(eyeParams);
 
@@ -188,7 +188,7 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
 
         // If the head is not positioned, updateEyeJoints won't get the math right
         glm::quat headOrientation;
-        _rig->getJointRotation(geometry.joints.headJointIndex, headOrientation);
+        _rig->getJointRotation(joints.headJointIndex, headOrientation);
         glm::vec3 eulers = safeEulerAngles(headOrientation);
         head->setBasePitch(glm::degrees(-eulers.x));
         head->setBaseYaw(glm::degrees(eulers.y));
@@ -200,8 +200,8 @@ void SkeletonModel::updateRig(float deltaTime, glm::mat4 parentTransform) {
         eyeParams.eyeSaccade = glm::vec3();
         eyeParams.modelRotation = getRotation();
         eyeParams.modelTranslation = getTranslation();
-        eyeParams.leftEyeJointIndex = geometry.joints.leftEyeJointIndex;
-        eyeParams.rightEyeJointIndex = geometry.joints.rightEyeJointIndex;
+        eyeParams.leftEyeJointIndex = joints.leftEyeJointIndex;
+        eyeParams.rightEyeJointIndex = joints.rightEyeJointIndex;
 
         _rig->updateFromEyeParameters(eyeParams);
      }
@@ -330,35 +330,35 @@ float SkeletonModel::getRightArmLength() const {
 }
 
 bool SkeletonModel::getHeadPosition(glm::vec3& headPosition) const {
-    return isActive() && getJointPositionInWorldFrame(getFBXGeometry().joints.headJointIndex, headPosition);
+    return isActive() && getJointPositionInWorldFrame(getGeometry()->getJoints().headJointIndex, headPosition);
 }
 
 bool SkeletonModel::getNeckPosition(glm::vec3& neckPosition) const {
-    return isActive() && getJointPositionInWorldFrame(getFBXGeometry().joints.neckJointIndex, neckPosition);
+    return isActive() && getJointPositionInWorldFrame(getGeometry()->getJoints().neckJointIndex, neckPosition);
 }
 
 bool SkeletonModel::getLocalNeckPosition(glm::vec3& neckPosition) const {
-    return isActive() && getJointPosition(getFBXGeometry().joints.neckJointIndex, neckPosition);
+    return isActive() && getJointPosition(getGeometry()->getJoints().neckJointIndex, neckPosition);
 }
 
 bool SkeletonModel::getEyeModelPositions(glm::vec3& firstEyePosition, glm::vec3& secondEyePosition) const {
     if (!isActive()) {
         return false;
     }
-    const FBXGeometry& geometry = getFBXGeometry();
+    const auto& joints = getGeometry()->getJoints();
 
-    if (getJointPosition(geometry.joints.leftEyeJointIndex, firstEyePosition) &&
-        getJointPosition(geometry.joints.rightEyeJointIndex, secondEyePosition)) {
+    if (getJointPosition(joints.leftEyeJointIndex, firstEyePosition) &&
+        getJointPosition(joints.rightEyeJointIndex, secondEyePosition)) {
         return true;
     }
     // no eye joints; try to estimate based on head/neck joints
     glm::vec3 neckPosition, headPosition;
-    if (getJointPosition(geometry.joints.neckJointIndex, neckPosition) &&
-        getJointPosition(geometry.joints.headJointIndex, headPosition)) {
+    if (getJointPosition(joints.neckJointIndex, neckPosition) &&
+        getJointPosition(joints.headJointIndex, headPosition)) {
         const float EYE_PROPORTION = 0.6f;
         glm::vec3 baseEyePosition = glm::mix(neckPosition, headPosition, EYE_PROPORTION);
         glm::quat headRotation;
-        getJointRotation(geometry.joints.headJointIndex, headRotation);
+        getJointRotation(joints.headJointIndex, headRotation);
         const float EYES_FORWARD = 0.25f;
         const float EYE_SEPARATION = 0.1f;
         float headHeight = glm::distance(neckPosition, headPosition);
@@ -392,15 +392,15 @@ void SkeletonModel::computeBoundingShape() {
         return;
     }
 
-    const FBXGeometry& geometry = getFBXGeometry();
-    if (geometry.joints.isEmpty() || geometry.joints.rootJointIndex == -1) {
+    const auto& joints = getGeometry()->getJoints();
+    if (joints.isEmpty() || joints.rootJointIndex == -1) {
         // rootJointIndex == -1 if the avatar model has no skeleton
         return;
     }
 
     float radius, height;
     glm::vec3 offset;
-    _rig->computeAvatarBoundingCapsule(geometry.joints, radius, height, offset);
+    _rig->computeAvatarBoundingCapsule(joints, radius, height, offset);
     float invScale = 1.0f / _owningAvatar->getUniformScale();
     _boundingCapsuleRadius = invScale * radius;
     _boundingCapsuleHeight = invScale * height;
@@ -431,7 +431,7 @@ void SkeletonModel::renderBoundingCollisionShapes(gpu::Batch& batch, float scale
 }
 
 bool SkeletonModel::hasSkeleton() {
-    return isActive() ? getFBXGeometry().joints.rootJointIndex != -1 : false;
+    return isActive() ? getGeometry()->getJoints().rootJointIndex != -1 : false;
 }
 
 void SkeletonModel::onInvalidate() {

--- a/interface/src/avatar/SkeletonModel.h
+++ b/interface/src/avatar/SkeletonModel.h
@@ -38,10 +38,10 @@ public:
     void updateAttitude();
 
     /// Returns the index of the left hand joint, or -1 if not found.
-    int getLeftHandJointIndex() const { return isActive() ? getFBXGeometry().leftHandJointIndex : -1; }
+    int getLeftHandJointIndex() const { return isActive() ? getFBXGeometry().joints.leftHandJointIndex : -1; }
 
     /// Returns the index of the right hand joint, or -1 if not found.
-    int getRightHandJointIndex() const { return isActive() ? getFBXGeometry().rightHandJointIndex : -1; }
+    int getRightHandJointIndex() const { return isActive() ? getFBXGeometry().joints.rightHandJointIndex : -1; }
 
     bool getLeftGrabPosition(glm::vec3& position) const;
     bool getRightGrabPosition(glm::vec3& position) const;

--- a/interface/src/avatar/SkeletonModel.h
+++ b/interface/src/avatar/SkeletonModel.h
@@ -38,10 +38,10 @@ public:
     void updateAttitude();
 
     /// Returns the index of the left hand joint, or -1 if not found.
-    int getLeftHandJointIndex() const { return isActive() ? getFBXGeometry().joints.leftHandJointIndex : -1; }
+    int getLeftHandJointIndex() const { return isActive() ? getGeometry()->getJoints().leftHandJointIndex : -1; }
 
     /// Returns the index of the right hand joint, or -1 if not found.
-    int getRightHandJointIndex() const { return isActive() ? getFBXGeometry().joints.rightHandJointIndex : -1; }
+    int getRightHandJointIndex() const { return isActive() ? getGeometry()->getJoints().rightHandJointIndex : -1; }
 
     bool getLeftGrabPosition(glm::vec3& position) const;
     bool getRightGrabPosition(glm::vec3& position) const;

--- a/interface/src/avatar/SoftAttachmentModel.cpp
+++ b/interface/src/avatar/SoftAttachmentModel.cpp
@@ -77,7 +77,7 @@ void SoftAttachmentModel::updateClusterMatrices(glm::vec3 modelPosition, glm::qu
     }
 
     // post the blender if we're not currently waiting for one to finish
-    if (geometry.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (geometry.meshes.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         DependencyManager::get<ModelBlender>()->noteRequiresBlend(getThisPointer());
     }

--- a/interface/src/avatar/SoftAttachmentModel.cpp
+++ b/interface/src/avatar/SoftAttachmentModel.cpp
@@ -43,12 +43,12 @@ void SoftAttachmentModel::updateClusterMatrices(glm::vec3 modelPosition, glm::qu
     }
     _needsUpdateClusterMatrices = false;
 
-    const FBXGeometry& geometry = getFBXGeometry();
+    const auto& meshes = getGeometry()->getMeshes();
 
     glm::mat4 modelToWorld = glm::mat4_cast(modelOrientation);
     for (int i = 0; i < _meshStates.size(); i++) {
         MeshState& state = _meshStates[i];
-        const FBXMesh& mesh = geometry.meshes.at(i);
+        const FBXMesh& mesh = meshes.at(i);
 
         for (int j = 0; j < mesh.clusters.size(); j++) {
             const FBXCluster& cluster = mesh.clusters.at(j);
@@ -77,7 +77,7 @@ void SoftAttachmentModel::updateClusterMatrices(glm::vec3 modelPosition, glm::qu
     }
 
     // post the blender if we're not currently waiting for one to finish
-    if (geometry.meshes.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
+    if (meshes.hasBlendedMeshes() && _blendshapeCoefficients != _blendedBlendshapeCoefficients) {
         _blendedBlendshapeCoefficients = _blendshapeCoefficients;
         DependencyManager::get<ModelBlender>()->noteRequiresBlend(getThisPointer());
     }

--- a/libraries/animation/src/AnimClip.cpp
+++ b/libraries/animation/src/AnimClip.cpp
@@ -101,7 +101,7 @@ void AnimClip::copyFromNetworkAnim() {
     // build a mapping from animation joint indices to skeleton joint indices.
     // by matching joints with the same name.
     const FBXGeometry& geom = _networkAnim->getGeometry();
-    AnimSkeleton animSkeleton(geom);
+    AnimSkeleton animSkeleton(geom.joints);
     const auto animJointCount = animSkeleton.getNumJoints();
     const auto skeletonJointCount = _skeleton->getNumJoints();
     std::vector<int> jointMap;

--- a/libraries/animation/src/AnimClip.cpp
+++ b/libraries/animation/src/AnimClip.cpp
@@ -100,8 +100,7 @@ void AnimClip::copyFromNetworkAnim() {
 
     // build a mapping from animation joint indices to skeleton joint indices.
     // by matching joints with the same name.
-    const FBXGeometry& geom = _networkAnim->getGeometry();
-    AnimSkeleton animSkeleton(geom.joints);
+    AnimSkeleton animSkeleton(_networkAnim->getJoints());
     const auto animJointCount = animSkeleton.getNumJoints();
     const auto skeletonJointCount = _skeleton->getNumJoints();
     std::vector<int> jointMap;
@@ -114,12 +113,13 @@ void AnimClip::copyFromNetworkAnim() {
         jointMap.push_back(skeletonJoint);
     }
 
-    const int frameCount = geom.animationFrames.size();
+    const auto& animationFrames = _networkAnim->getFramesReference();
+    const int frameCount = animationFrames.size();
     _anim.resize(frameCount);
 
     for (int frame = 0; frame < frameCount; frame++) {
 
-        const FBXAnimationFrame& fbxAnimFrame = geom.animationFrames[frame];
+        const auto& fbxAnimFrame = animationFrames[frame];
 
         // init all joints in animation to default pose
         // this will give us a resonable result for bones in the model skeleton but not in the animation.
@@ -155,7 +155,7 @@ void AnimClip::copyFromNetworkAnim() {
 
                 // adjust translation offsets, so large translation animatons on the reference skeleton
                 // will be adjusted when played on a skeleton with short limbs.
-                const glm::vec3& fbxZeroTrans = geom.animationFrames[0].translations[animJoint];
+                const glm::vec3& fbxZeroTrans = animationFrames[0].translations[animJoint];
                 const AnimPose& relDefaultPose = _skeleton->getRelativeDefaultPose(skeletonJoint);
                 float boneLengthScale = 1.0f;
                 const float EPSILON = 0.0001f;

--- a/libraries/animation/src/AnimSkeleton.cpp
+++ b/libraries/animation/src/AnimSkeleton.cpp
@@ -16,17 +16,7 @@
 
 #include "AnimationLogging.h"
 
-AnimSkeleton::AnimSkeleton(const FBXGeometry& fbxGeometry) {
-    // convert to std::vector of joints
-    std::vector<FBXJoint> joints;
-    joints.reserve(fbxGeometry.joints.size());
-    for (auto& joint : fbxGeometry.joints) {
-        joints.push_back(joint);
-    }
-    buildSkeletonFromJoints(joints);
-}
-
-AnimSkeleton::AnimSkeleton(const std::vector<FBXJoint>& joints) {
+AnimSkeleton::AnimSkeleton(const FBXJoints& joints) {
     buildSkeletonFromJoints(joints);
 }
 
@@ -120,7 +110,7 @@ void AnimSkeleton::mirrorAbsolutePoses(AnimPoseVec& poses) const {
     }
 }
 
-void AnimSkeleton::buildSkeletonFromJoints(const std::vector<FBXJoint>& joints) {
+void AnimSkeleton::buildSkeletonFromJoints(const FBXJoints& joints) {
     _joints = joints;
 
     // build a cache of bind poses

--- a/libraries/animation/src/AnimSkeleton.h
+++ b/libraries/animation/src/AnimSkeleton.h
@@ -23,8 +23,7 @@ public:
     using Pointer = std::shared_ptr<AnimSkeleton>;
     using ConstPointer = std::shared_ptr<const AnimSkeleton>;
 
-    explicit AnimSkeleton(const FBXGeometry& fbxGeometry);
-    explicit AnimSkeleton(const std::vector<FBXJoint>& joints);
+    explicit AnimSkeleton(const FBXJoints& joints);
     int nameToJointIndex(const QString& jointName) const;
     const QString& getJointName(int jointIndex) const;
     int getNumJoints() const;
@@ -64,9 +63,9 @@ public:
 #endif
 
 protected:
-    void buildSkeletonFromJoints(const std::vector<FBXJoint>& joints);
+    void buildSkeletonFromJoints(const FBXJoints& joints);
 
-    std::vector<FBXJoint> _joints;
+    FBXJoints _joints;
     AnimPoseVec _absoluteBindPoses;
     AnimPoseVec _relativeBindPoses;
     AnimPoseVec _relativeDefaultPoses;

--- a/libraries/animation/src/AnimationCache.h
+++ b/libraries/animation/src/AnimationCache.h
@@ -53,16 +53,14 @@ public:
 
     explicit Animation(const QUrl& url);
 
-    const FBXGeometry& getGeometry() const { return *_geometry; }
-
     virtual bool isLoaded() const override;
 
+    const FBXJoints& getJoints() const { return *_joints; }
+    const FBXAnimationFrames& getFramesReference() const { return *_animationFrames; }
     
     Q_INVOKABLE QStringList getJointNames() const;
-    
-    Q_INVOKABLE QVector<FBXAnimationFrame> getFrames() const;
+    Q_INVOKABLE FBXAnimationFrames getFrames() const;
 
-    const QVector<FBXAnimationFrame>& getFramesReference() const;
     
 protected:
     virtual void downloadFinished(const QByteArray& data) override;
@@ -72,8 +70,8 @@ protected slots:
     void animationParseError(int error, QString str);
 
 private:
-    
-    std::unique_ptr<FBXGeometry> _geometry;
+    std::unique_ptr<FBXJoints> _joints;
+    std::unique_ptr<FBXAnimationFrames> _animationFrames;
 };
 
 /// Reads geometry in a worker thread.

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -158,12 +158,12 @@ void Rig::destroyAnimGraph() {
     _internalPoseSet._overrideFlags.clear();
 }
 
-void Rig::initJointStates(const FBXGeometry& geometry, const glm::mat4& modelOffset) {
+void Rig::initJointStates(const FBXJoints& joints, const glm::mat4& modelOffset) {
 
-    _geometryOffset = AnimPose(geometry.offset);
+    _geometryOffset = AnimPose(joints.offset);
     setModelOffset(modelOffset);
 
-    _animSkeleton = std::make_shared<AnimSkeleton>(geometry);
+    _animSkeleton = std::make_shared<AnimSkeleton>(joints);
 
     _internalPoseSet._relativePoses.clear();
     _internalPoseSet._relativePoses = _animSkeleton->getRelativeDefaultPoses();
@@ -178,18 +178,18 @@ void Rig::initJointStates(const FBXGeometry& geometry, const glm::mat4& modelOff
 
     buildAbsoluteRigPoses(_animSkeleton->getRelativeDefaultPoses(), _absoluteDefaultPoses);
 
-    _rootJointIndex = geometry.rootJointIndex;
-    _leftHandJointIndex = geometry.leftHandJointIndex;
-    _leftElbowJointIndex = _leftHandJointIndex >= 0 ? geometry.joints.at(_leftHandJointIndex).parentIndex : -1;
-    _leftShoulderJointIndex = _leftElbowJointIndex >= 0 ? geometry.joints.at(_leftElbowJointIndex).parentIndex : -1;
-    _rightHandJointIndex = geometry.rightHandJointIndex;
-    _rightElbowJointIndex = _rightHandJointIndex >= 0 ? geometry.joints.at(_rightHandJointIndex).parentIndex : -1;
-    _rightShoulderJointIndex = _rightElbowJointIndex >= 0 ? geometry.joints.at(_rightElbowJointIndex).parentIndex : -1;
+    _rootJointIndex = joints.rootJointIndex;
+    _leftHandJointIndex = joints.leftHandJointIndex;
+    _leftElbowJointIndex = _leftHandJointIndex >= 0 ? joints.at(_leftHandJointIndex).parentIndex : -1;
+    _leftShoulderJointIndex = _leftElbowJointIndex >= 0 ? joints.at(_leftElbowJointIndex).parentIndex : -1;
+    _rightHandJointIndex = joints.rightHandJointIndex;
+    _rightElbowJointIndex = _rightHandJointIndex >= 0 ? joints.at(_rightHandJointIndex).parentIndex : -1;
+    _rightShoulderJointIndex = _rightElbowJointIndex >= 0 ? joints.at(_rightElbowJointIndex).parentIndex : -1;
 }
 
-void Rig::reset(const FBXGeometry& geometry) {
-    _geometryOffset = AnimPose(geometry.offset);
-    _animSkeleton = std::make_shared<AnimSkeleton>(geometry);
+void Rig::reset(const FBXJoints& joints) {
+    _geometryOffset = AnimPose(joints.offset);
+    _animSkeleton = std::make_shared<AnimSkeleton>(joints);
 
     _internalPoseSet._relativePoses.clear();
     _internalPoseSet._relativePoses = _animSkeleton->getRelativeDefaultPoses();
@@ -204,13 +204,13 @@ void Rig::reset(const FBXGeometry& geometry) {
 
     buildAbsoluteRigPoses(_animSkeleton->getRelativeDefaultPoses(), _absoluteDefaultPoses);
 
-    _rootJointIndex = geometry.rootJointIndex;
-    _leftHandJointIndex = geometry.leftHandJointIndex;
-    _leftElbowJointIndex = _leftHandJointIndex >= 0 ? geometry.joints.at(_leftHandJointIndex).parentIndex : -1;
-    _leftShoulderJointIndex = _leftElbowJointIndex >= 0 ? geometry.joints.at(_leftElbowJointIndex).parentIndex : -1;
-    _rightHandJointIndex = geometry.rightHandJointIndex;
-    _rightElbowJointIndex = _rightHandJointIndex >= 0 ? geometry.joints.at(_rightHandJointIndex).parentIndex : -1;
-    _rightShoulderJointIndex = _rightElbowJointIndex >= 0 ? geometry.joints.at(_rightElbowJointIndex).parentIndex : -1;
+    _rootJointIndex = joints.rootJointIndex;
+    _leftHandJointIndex = joints.leftHandJointIndex;
+    _leftElbowJointIndex = _leftHandJointIndex >= 0 ? joints.at(_leftHandJointIndex).parentIndex : -1;
+    _leftShoulderJointIndex = _leftElbowJointIndex >= 0 ? joints.at(_leftElbowJointIndex).parentIndex : -1;
+    _rightHandJointIndex = joints.rightHandJointIndex;
+    _rightElbowJointIndex = _rightHandJointIndex >= 0 ? joints.at(_rightHandJointIndex).parentIndex : -1;
+    _rightShoulderJointIndex = _rightElbowJointIndex >= 0 ? joints.at(_rightElbowJointIndex).parentIndex : -1;
 
     if (!_animGraphURL.isEmpty()) {
         initAnimGraph(_animGraphURL);
@@ -896,7 +896,7 @@ bool Rig::restoreJointPosition(int jointIndex, float fraction, float priority, c
 }
 
 float Rig::getLimbLength(int jointIndex, const QVector<int>& freeLineage,
-                         const glm::vec3 scale, const QVector<FBXJoint>& fbxJoints) const {
+                         const glm::vec3 scale, const FBXJoints& fbxJoints) const {
     ASSERT(false);
     return 1.0f;
 }
@@ -1216,7 +1216,7 @@ void Rig::copyJointsFromJointData(const QVector<JointData>& jointDataVec) {
 }
 
 void Rig::computeAvatarBoundingCapsule(
-        const FBXGeometry& geometry,
+        const FBXJoints& joints,
         float& radiusOut,
         float& heightOut,
         glm::vec3& localOffsetOut) const {
@@ -1300,7 +1300,7 @@ void Rig::computeAvatarBoundingCapsule(
     // from the head to the hips when computing the rest of the bounding capsule.
     int index = indexOfJoint("Head");
     while (index != -1) {
-        const FBXJointShapeInfo& shapeInfo = geometry.joints.at(index).shapeInfo;
+        const FBXJointShapeInfo& shapeInfo = joints.at(index).shapeInfo;
         AnimPose pose = finalPoses[index];
         if (shapeInfo.points.size() > 0) {
             for (int j = 0; j < shapeInfo.points.size(); ++j) {
@@ -1317,7 +1317,7 @@ void Rig::computeAvatarBoundingCapsule(
     radiusOut = 0.5f * sqrtf(0.5f * (diagonal.x * diagonal.x + diagonal.z * diagonal.z));
     heightOut = diagonal.y - 2.0f * radiusOut;
 
-    glm::vec3 rootPosition = finalPoses[geometry.rootJointIndex].trans;
+    glm::vec3 rootPosition = finalPoses[joints.rootJointIndex].trans;
     glm::vec3 rigCenter = (geometryToRig * (0.5f * (totalExtents.maximum + totalExtents.minimum)));
     localOffsetOut = rigCenter - (geometryToRig * rootPosition);
 }

--- a/libraries/animation/src/Rig.cpp
+++ b/libraries/animation/src/Rig.cpp
@@ -1300,7 +1300,7 @@ void Rig::computeAvatarBoundingCapsule(
     // from the head to the hips when computing the rest of the bounding capsule.
     int index = indexOfJoint("Head");
     while (index != -1) {
-        const FBXJointShapeInfo& shapeInfo = joints.at(index).shapeInfo;
+        const auto& shapeInfo = joints.at(index).shapeInfo;
         AnimPose pose = finalPoses[index];
         if (shapeInfo.points.size() > 0) {
             for (int j = 0; j < shapeInfo.points.size(); ++j) {

--- a/libraries/animation/src/Rig.h
+++ b/libraries/animation/src/Rig.h
@@ -95,8 +95,8 @@ public:
     void restoreRoleAnimation(const QString& role);
     void prefetchAnimation(const QString& url);
 
-    void initJointStates(const FBXGeometry& geometry, const glm::mat4& modelOffset);
-    void reset(const FBXGeometry& geometry);
+    void initJointStates(const FBXJoints& joints, const glm::mat4& modelOffset);
+    void reset(const FBXJoints& joints);
     bool jointStatesEmpty();
     int getJointStateCount() const;
     int indexOfJoint(const QString& jointName) const;
@@ -166,7 +166,7 @@ public:
 
     // legacy
     float getLimbLength(int jointIndex, const QVector<int>& freeLineage,
-                        const glm::vec3 scale, const QVector<FBXJoint>& fbxJoints) const;
+                        const glm::vec3 scale, const FBXJoints& fbxJoints) const;
 
     // legacy
     glm::quat setJointRotationInBindFrame(int jointIndex, const glm::quat& rotation, float priority);
@@ -217,7 +217,7 @@ public:
     void copyJointsIntoJointData(QVector<JointData>& jointDataVec) const;
     void copyJointsFromJointData(const QVector<JointData>& jointDataVec);
 
-    void computeAvatarBoundingCapsule(const FBXGeometry& geometry, float& radiusOut, float& heightOut, glm::vec3& offsetOut) const;
+    void computeAvatarBoundingCapsule(const FBXJoints& joints, float& radiusOut, float& heightOut, glm::vec3& offsetOut) const;
 
     void setEnableInverseKinematics(bool enable);
 

--- a/libraries/entities-renderer/src/EntityTreeRenderer.cpp
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.cpp
@@ -102,7 +102,7 @@ void EntityTreeRenderer::reloadEntityScripts() {
 void EntityTreeRenderer::init() {
     OctreeRenderer::init();
     EntityTreePointer entityTree = std::static_pointer_cast<EntityTree>(_tree);
-    entityTree->setFBXService(this);
+    entityTree->setGeometryService(this);
 
     if (_wantScripts) {
         _entitiesScriptEngine = new ScriptEngine(NO_SCRIPT, "Entities");
@@ -126,7 +126,7 @@ void EntityTreeRenderer::shutdown() {
 
 void EntityTreeRenderer::setTree(OctreePointer newTree) {
     OctreeRenderer::setTree(newTree);
-    std::static_pointer_cast<EntityTree>(_tree)->setFBXService(this);
+    std::static_pointer_cast<EntityTree>(_tree)->setGeometryService(this);
 }
 
 void EntityTreeRenderer::update() {
@@ -437,19 +437,19 @@ void EntityTreeRenderer::applyZonePropertiesToScene(std::shared_ptr<ZoneEntityIt
     }
 }
 
-const FBXGeometry* EntityTreeRenderer::getGeometryForEntity(EntityItemPointer entityItem) {
-    const FBXGeometry* result = NULL;
-
+bool EntityTreeRenderer::getGeometryForEntity(EntityItemPointer entityItem, SittingPoints& sittingPoints, Extents& extents) {
     if (entityItem->getType() == EntityTypes::Model) {
         std::shared_ptr<RenderableModelEntityItem> modelEntityItem =
-                                                        std::dynamic_pointer_cast<RenderableModelEntityItem>(entityItem);
+            std::dynamic_pointer_cast<RenderableModelEntityItem>(entityItem);
         assert(modelEntityItem); // we need this!!!
         ModelPointer model = modelEntityItem->getModel(this);
         if (model && model->isLoaded()) {
-            result = &model->getFBXGeometry();
+            sittingPoints = model->getGeometry()->getSittingPoints();
+            extents = model->getGeometry()->getMeshes().getUnscaledMeshExtents();
+            return true;
         }
     }
-    return result;
+    return false;
 }
 
 ModelPointer EntityTreeRenderer::getModelForEntityItem(EntityItemPointer entityItem) {
@@ -458,22 +458,6 @@ ModelPointer EntityTreeRenderer::getModelForEntityItem(EntityItemPointer entityI
         std::shared_ptr<RenderableModelEntityItem> modelEntityItem =
                                                         std::dynamic_pointer_cast<RenderableModelEntityItem>(entityItem);
         result = modelEntityItem->getModel(this);
-    }
-    return result;
-}
-
-const FBXGeometry* EntityTreeRenderer::getCollisionGeometryForEntity(EntityItemPointer entityItem) {
-    const FBXGeometry* result = NULL;
-    
-    if (entityItem->getType() == EntityTypes::Model) {
-        std::shared_ptr<RenderableModelEntityItem> modelEntityItem =
-                                                        std::dynamic_pointer_cast<RenderableModelEntityItem>(entityItem);
-        if (modelEntityItem->hasCompoundShapeURL()) {
-            ModelPointer model = modelEntityItem->getModel(this);
-            if (model && model->isCollisionLoaded()) {
-                result = &model->getCollisionFBXGeometry();
-            }
-        }
     }
     return result;
 }

--- a/libraries/entities-renderer/src/EntityTreeRenderer.h
+++ b/libraries/entities-renderer/src/EntityTreeRenderer.h
@@ -34,7 +34,7 @@ using ModelPointer = std::shared_ptr<Model>;
 using ModelWeakPointer = std::weak_ptr<Model>;
 
 // Generic client side Octree renderer class.
-class EntityTreeRenderer : public OctreeRenderer, public EntityItemFBXService, public Dependency {
+class EntityTreeRenderer : public OctreeRenderer, public EntityItemGeometryService, public Dependency {
     Q_OBJECT
 public:
     EntityTreeRenderer(bool wantScripts, AbstractViewStateInterface* viewState,
@@ -55,9 +55,8 @@ public:
 
     virtual void init();
 
-    virtual const FBXGeometry* getGeometryForEntity(EntityItemPointer entityItem);
+    virtual bool getGeometryForEntity(EntityItemPointer entityItem, SittingPoints& sittingPoints, Extents& extents);
     virtual ModelPointer getModelForEntityItem(EntityItemPointer entityItem);
-    virtual const FBXGeometry* getCollisionGeometryForEntity(EntityItemPointer entityItem);
     
     /// clears the tree
     virtual void clear();

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -277,8 +277,8 @@ bool RenderableModelEntityItem::getAnimationFrame() {
     AnimationPointer myAnimation = getAnimation(getRenderAnimationURL()); // FIXME: this could be optimized
     if (myAnimation && myAnimation->isLoaded()) {
 
-        const QVector<FBXAnimationFrame>&  frames = myAnimation->getFramesReference(); // NOTE: getFrames() is too heavy
-        auto& fbxJoints = myAnimation->getGeometry().joints;
+        const auto&  frames = myAnimation->getFramesReference(); // NOTE: getFrames() is too heavy
+        const auto& fbxJoints = myAnimation->getJoints();
 
         int frameCount = frames.size();
         if (frameCount > 0) {

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -693,7 +693,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         // to the visual model and apply them to the collision model (without regard for the
         // collision model's extents).
 
-        glm::vec3 scale = getDimensions() / renderGeometry.getUnscaledMeshExtents().size();
+        glm::vec3 scale = getDimensions() / renderGeometry.meshes.getUnscaledMeshExtents().size();
         // multiply each point by scale before handing the point-set off to the physics engine.
         // also determine the extents of the collision model.
         AABox box;
@@ -719,7 +719,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
 
 bool RenderableModelEntityItem::contains(const glm::vec3& point) const {
     if (EntityItem::contains(point) && _model && _model->isCollisionLoaded()) {
-        return _model->getCollisionFBXGeometry().convexHullContains(worldToEntity(point));
+        return _model->getCollisionFBXGeometry().meshes.convexHullContains(worldToEntity(point));
     }
 
     return false;

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -625,7 +625,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         // to find one actual "mesh" (with one or more meshParts in it), but we loop over the meshes, just in case.
         foreach (const auto& mesh, collisionGeometry->getMeshes()) {
             // each meshPart is a convex hull
-            foreach (const FBXMeshPart &meshPart, mesh.parts) {
+            foreach (const auto&meshPart, mesh.parts) {
                 QVector<glm::vec3> pointsInPart;
 
                 // run through all the triangles and (uniquely) add each point to the hull

--- a/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
+++ b/libraries/entities-renderer/src/RenderableModelEntityItem.cpp
@@ -615,15 +615,15 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         // should never fall in here when collision model not fully loaded
         // hence we assert that all geometries exist and are loaded
         assert(_model->isLoaded() && _model->isCollisionLoaded());
-        const FBXGeometry& renderGeometry = _model->getFBXGeometry();
-        const FBXGeometry& collisionGeometry = _model->getCollisionFBXGeometry();
+        const auto& renderGeometry = _model->getGeometry();
+        const auto& collisionGeometry = _model->getCollisionGeometry();
 
         _points.clear();
         unsigned int i = 0;
 
         // the way OBJ files get read, each section under a "g" line is its own meshPart.  We only expect
         // to find one actual "mesh" (with one or more meshParts in it), but we loop over the meshes, just in case.
-        foreach (const FBXMesh& mesh, collisionGeometry.meshes) {
+        foreach (const auto& mesh, collisionGeometry->getMeshes()) {
             // each meshPart is a convex hull
             foreach (const FBXMeshPart &meshPart, mesh.parts) {
                 QVector<glm::vec3> pointsInPart;
@@ -693,7 +693,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
         // to the visual model and apply them to the collision model (without regard for the
         // collision model's extents).
 
-        glm::vec3 scale = getDimensions() / renderGeometry.meshes.getUnscaledMeshExtents().size();
+        glm::vec3 scale = getDimensions() / renderGeometry->getMeshes().getUnscaledMeshExtents().size();
         // multiply each point by scale before handing the point-set off to the physics engine.
         // also determine the extents of the collision model.
         AABox box;
@@ -719,7 +719,7 @@ void RenderableModelEntityItem::computeShapeInfo(ShapeInfo& info) {
 
 bool RenderableModelEntityItem::contains(const glm::vec3& point) const {
     if (EntityItem::contains(point) && _model && _model->isCollisionLoaded()) {
-        return _model->getCollisionFBXGeometry().meshes.convexHullContains(worldToEntity(point));
+        return _model->getCollisionGeometry()->getMeshes().convexHullContains(worldToEntity(point));
     }
 
     return false;

--- a/libraries/entities/src/EntityItemProperties.cpp
+++ b/libraries/entities/src/EntityItemProperties.cpp
@@ -51,7 +51,7 @@ _desiredProperties(desiredProperties)
 {
 }
 
-void EntityItemProperties::setSittingPoints(const QVector<SittingPoint>& sittingPoints) {
+void EntityItemProperties::setSittingPoints(const SittingPoints& sittingPoints) {
     _sittingPoints.clear();
     foreach (SittingPoint sitPoint, sittingPoints) {
         _sittingPoints.append(sitPoint);

--- a/libraries/entities/src/EntityItemProperties.h
+++ b/libraries/entities/src/EntityItemProperties.h
@@ -237,7 +237,7 @@ public:
     void clearID() { _id = UNKNOWN_ENTITY_ID; _idSet = false; }
     void markAllChanged();
 
-    void setSittingPoints(const QVector<SittingPoint>& sittingPoints);
+    void setSittingPoints(const SittingPoints& sittingPoints);
 
     const glm::vec3& getNaturalDimensions() const { return _naturalDimensions; }
     void setNaturalDimensions(const glm::vec3& value) { _naturalDimensions = value; }
@@ -296,7 +296,7 @@ private:
 
     // NOTE: The following are pseudo client only properties. They are only used in clients which can access
     // properties of model geometry. But these properties are not serialized like other properties.
-    QVector<SittingPoint> _sittingPoints;
+    SittingPoints _sittingPoints;
     QVariantMap _textureNames;
     glm::vec3 _naturalDimensions;
     glm::vec3 _naturalPosition;

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -229,7 +229,7 @@ EntityItemProperties EntityScriptingInterface::getEntityProperties(QUuid identit
                     const FBXGeometry* geometry = _entityTree->getGeometryForEntity(entity);
                     if (geometry) {
                         results.setSittingPoints(geometry->sittingPoints);
-                        Extents meshExtents = geometry->getUnscaledMeshExtents();
+                        Extents meshExtents = geometry->meshes.getUnscaledMeshExtents();
                         results.setNaturalDimensions(meshExtents.maximum - meshExtents.minimum);
                         results.calculateNaturalPosition(meshExtents.minimum, meshExtents.maximum);
                     }

--- a/libraries/entities/src/EntityScriptingInterface.cpp
+++ b/libraries/entities/src/EntityScriptingInterface.cpp
@@ -226,12 +226,13 @@ EntityItemProperties EntityScriptingInterface::getEntityProperties(QUuid identit
                 //       for now we've included the old sitting points model behavior for entity types that are models
                 //        we've also added this hack for setting natural dimensions of models
                 if (entity->getType() == EntityTypes::Model) {
-                    const FBXGeometry* geometry = _entityTree->getGeometryForEntity(entity);
-                    if (geometry) {
-                        results.setSittingPoints(geometry->sittingPoints);
-                        Extents meshExtents = geometry->meshes.getUnscaledMeshExtents();
-                        results.setNaturalDimensions(meshExtents.maximum - meshExtents.minimum);
-                        results.calculateNaturalPosition(meshExtents.minimum, meshExtents.maximum);
+                    SittingPoints sittingPoints;
+                    Extents extents;
+                    bool success = _entityTree->getGeometryForEntity(entity, sittingPoints, extents);
+                    if (success) {
+                        results.setSittingPoints(sittingPoints);
+                        results.setNaturalDimensions(extents.maximum - extents.minimum);
+                        results.calculateNaturalPosition(extents.minimum, extents.maximum);
                     }
                 }
 

--- a/libraries/entities/src/EntityTree.cpp
+++ b/libraries/entities/src/EntityTree.cpp
@@ -29,7 +29,7 @@ static const quint64 DELETED_ENTITIES_EXTRA_USECS_TO_CONSIDER = USECS_PER_MSEC *
 
 EntityTree::EntityTree(bool shouldReaverage) :
     Octree(shouldReaverage),
-    _fbxService(NULL),
+    _geometryService(NULL),
     _simulation(NULL)
 {
     resetClientEditStats();

--- a/libraries/entities/src/EntityTree.h
+++ b/libraries/entities/src/EntityTree.h
@@ -36,11 +36,10 @@ public:
     virtual void entityCreated(const EntityItem& newEntity, const SharedNodePointer& senderNode) = 0;
 };
 
-class EntityItemFBXService {
+class EntityItemGeometryService {
 public:
-    virtual const FBXGeometry* getGeometryForEntity(EntityItemPointer entityItem) = 0;
+    virtual bool getGeometryForEntity(EntityItemPointer entityItem, SittingPoints&, Extents&) = 0;
     virtual ModelPointer getModelForEntityItem(EntityItemPointer entityItem) = 0;
-    virtual const FBXGeometry* getCollisionGeometryForEntity(EntityItemPointer entityItem) = 0;
 };
 
 
@@ -172,13 +171,13 @@ public:
     int processEraseMessage(ReceivedMessage& message, const SharedNodePointer& sourceNode);
     int processEraseMessageDetails(const QByteArray& buffer, const SharedNodePointer& sourceNode);
 
-    EntityItemFBXService* getFBXService() const { return _fbxService; }
-    void setFBXService(EntityItemFBXService* service) { _fbxService = service; }
-    const FBXGeometry* getGeometryForEntity(EntityItemPointer entityItem) {
-        return _fbxService ? _fbxService->getGeometryForEntity(entityItem) : NULL;
+    EntityItemGeometryService* getGeometryService() const { return _geometryService; }
+    void setGeometryService(EntityItemGeometryService* service) { _geometryService = service; }
+    bool getGeometryForEntity(EntityItemPointer entityItem, SittingPoints& sittingPoints, Extents& extents) {
+        return _geometryService ? _geometryService->getGeometryForEntity(entityItem, sittingPoints, extents) : false;
     }
     ModelPointer getModelForEntityItem(EntityItemPointer entityItem) {
-        return _fbxService ? _fbxService->getModelForEntityItem(entityItem) : NULL;
+        return _geometryService ? _geometryService->getModelForEntityItem(entityItem) : NULL;
     }
 
     EntityTreeElementPointer getContainingElement(const EntityItemID& entityItemID)  /*const*/;
@@ -292,7 +291,7 @@ protected:
         _deletedEntityItemIDs << id;
     }
 
-    EntityItemFBXService* _fbxService;
+    EntityItemGeometryService* _geometryService;
 
     mutable QReadWriteLock _entityToElementLock;
     QHash<EntityItemID, EntityTreeElementPointer> _entityToElementMap;

--- a/libraries/fbx/src/FBXReader.h
+++ b/libraries/fbx/src/FBXReader.h
@@ -267,23 +267,10 @@ inline bool operator!=(const SittingPoint& lhs, const SittingPoint& rhs)
     return (lhs.name != rhs.name) || (lhs.position != rhs.position) || (lhs.rotation != rhs.rotation);
 }
 
-/// A set of meshes extracted from an FBX document.
-class FBXGeometry {
+class FBXJoints : public QVector<FBXJoint> {
 public:
-
-    QString author;
-    QString applicationName; ///< the name of the application that generated the model
-
-    QVector<FBXJoint> joints;
-    QHash<QString, int> jointIndices; ///< 1-based, so as to more easily detect missing indices
-    bool hasSkeletonJoints;
-    
-    QVector<FBXMesh> meshes;
-
-    QHash<QString, FBXMaterial> materials;
-
-    glm::mat4 offset;
-    
+    QHash<QString, int> indices; ///< 1-based, so as to more easily detect missing indices
+ 
     int leftEyeJointIndex = -1;
     int rightEyeJointIndex = -1;
     int neckJointIndex = -1;
@@ -295,38 +282,71 @@ public:
     int leftToeJointIndex = -1;
     int rightToeJointIndex = -1;
 
+    glm::mat4 offset;
+
+    int getJointIndex(const QString& name) const { return indices.value(name) - 1; }
+    QStringList getJointNames() const;
+
+    bool hasSkeletonJoints() const { return _hasSkeletonJoints; }
+
+protected:
+    friend class FBXReader;
+
+    bool _hasSkeletonJoints;
+};
+
+class FBXMeshes : public QVector<FBXMesh> {
+public:
+    Extents meshExtents;
+    Extents bindExtents;
+
     float leftEyeSize = 0.0f;  // Maximum mesh extents dimension
     float rightEyeSize = 0.0f;
 
-    QVector<int> humanIKJointIndices;
-    
-    glm::vec3 palmDirection;
-    
-    QVector<SittingPoint> sittingPoints;
-    
-    glm::vec3 neckPivot;
-    
-    Extents bindExtents;
-    Extents meshExtents;
-    
-    QVector<FBXAnimationFrame> animationFrames;
-        
-    int getJointIndex(const QString& name) const { return jointIndices.value(name) - 1; }
-    QStringList getJointNames() const;
-    
-    bool hasBlendedMeshes() const;
+    glm::mat4 offset;
 
-    /// Returns the unscaled extents of the model's mesh
     Extents getUnscaledMeshExtents() const;
+
+    QString getModelNameOfMesh(int meshIndex) const;
+
+    bool hasBlendedMeshes() const;
 
     bool convexHullContains(const glm::vec3& point) const;
 
-    QHash<int, QString> meshIndicesToModelNames;
-    
-    /// given a meshIndex this will return the name of the model that mesh belongs to if known
-    QString getModelNameOfMesh(int meshIndex) const;
-    
+protected:
+    friend class FBXReader;
+
+    QHash<int, QString> _meshIndicesToModelNames;
+
+    bool convexHullContainsHelper(const glm::vec3& point, const FBXMesh& mesh,
+                                const QVector<int>& indices, int primitiveSize) const;
+};
+
+using FBXMaterials = QHash<QString, FBXMaterial>;
+using FBXAnimationFrames = QVector<FBXAnimationFrame>;
+using SittingPoints = QVector<SittingPoint>;
+
+/// A set of meshes extracted from an FBX document.
+class FBXGeometry {
+public:
+    QString author;
+    QString applicationName; ///< the name of the application that generated the model
     QList<QString> blendshapeChannelNames;
+
+    FBXJoints joints;
+    FBXMeshes meshes;
+    FBXMaterials materials;
+    FBXAnimationFrames animationFrames;
+    SittingPoints sittingPoints;
+
+protected:
+    friend class FBXReader;
+
+    // unused
+    QVector<int> _humanIKJointIndices;
+
+    glm::vec3 _palmDirection;
+    glm::vec3 _neckPivot;
 };
 
 Q_DECLARE_METATYPE(FBXGeometry)

--- a/libraries/fbx/src/OBJReader.cpp
+++ b/libraries/fbx/src/OBJReader.cpp
@@ -419,7 +419,7 @@ FBXGeometry* OBJReader::readOBJ(QByteArray& model, const QVariantHash& mapping, 
     bool needsMaterialLibrary = false;
 
     _url = url;
-    geometry.meshExtents.reset();
+    geometry.meshes.meshExtents.reset();
     geometry.meshes.append(FBXMesh());
 
     try {
@@ -440,7 +440,7 @@ FBXGeometry* OBJReader::readOBJ(QByteArray& model, const QVariantHash& mapping, 
         geometry.joints[0].name = "OBJ";
         geometry.joints[0].isSkeletonJoint = true;
 
-        geometry.jointIndices["x"] = 1;
+        geometry.joints.indices["x"] = 1;
 
         FBXCluster cluster;
         cluster.jointIndex = 0;
@@ -521,7 +521,7 @@ FBXGeometry* OBJReader::readOBJ(QByteArray& model, const QVariantHash& mapping, 
         mesh.meshExtents.reset();
         foreach (const glm::vec3& vertex, mesh.vertices) {
             mesh.meshExtents.addPoint(vertex);
-            geometry.meshExtents.addPoint(vertex);
+            geometry.meshes.meshExtents.addPoint(vertex);
         }
 
         FBXReader::buildModelMesh(mesh, url.toString());
@@ -617,8 +617,8 @@ FBXGeometry* OBJReader::readOBJ(QByteArray& model, const QVariantHash& mapping, 
 
 void fbxDebugDump(const FBXGeometry& fbxgeo) {
     qCDebug(modelformat) << "---------------- fbxGeometry ----------------";
-    qCDebug(modelformat) << "  hasSkeletonJoints =" << fbxgeo.hasSkeletonJoints;
-    qCDebug(modelformat) << "  offset =" << fbxgeo.offset;
+    qCDebug(modelformat) << "  hasSkeletonJoints =" << fbxgeo.joints.hasSkeletonJoints();
+    qCDebug(modelformat) << "  offset =" << fbxgeo.joints.offset;
     qCDebug(modelformat) << "  meshes.count() =" << fbxgeo.meshes.count();
     foreach (FBXMesh mesh, fbxgeo.meshes) {
         qCDebug(modelformat) << "    vertices.count() =" << mesh.vertices.count();
@@ -660,7 +660,7 @@ void fbxDebugDump(const FBXGeometry& fbxgeo) {
         }
     }
 
-    qCDebug(modelformat) << "  jointIndices =" << fbxgeo.jointIndices;
+    qCDebug(modelformat) << "  jointIndices =" << fbxgeo.joints.indices;
     qCDebug(modelformat) << "  joints.count() =" << fbxgeo.joints.count();
 
     foreach (FBXJoint joint, fbxgeo.joints) {

--- a/libraries/model-networking/src/model-networking/ModelCache.cpp
+++ b/libraries/model-networking/src/model-networking/ModelCache.cpp
@@ -84,10 +84,11 @@ void GeometryMappingResource::downloadFinished(const QByteArray& data) {
 
 void GeometryMappingResource::onGeometryMappingLoaded(bool success) {
     if (success) {
-        _geometry = _geometryResource->_geometry;
-        _shapes = _geometryResource->_shapes;
+        _joints = _geometryResource->_joints;
         _meshes = _geometryResource->_meshes;
+        _sittingPoints = _geometryResource->_sittingPoints;
         _materials = _geometryResource->_materials;
+        _shapes = _geometryResource->_shapes;
     }
 
     // Avoid holding onto extra references
@@ -194,30 +195,31 @@ void GeometryDefinitionResource::downloadFinished(const QByteArray& data) {
 
 void GeometryDefinitionResource::setGeometryDefinition(void* fbxGeometry) {
     // Assume ownership of the geometry pointer
-    _geometry.reset(static_cast<FBXGeometry*>(fbxGeometry));
+    std::unique_ptr<FBXGeometry> geometry(static_cast<FBXGeometry*>(fbxGeometry));
 
-    // Copy materials
+    // Move in joints, meshes, sitting points, and materials
+    _joints = std::make_shared<NetworkJoints>(std::move(geometry->joints));
+    _meshes = std::make_shared<NetworkMeshes>(std::move(geometry->meshes));
+    _sittingPoints = std::make_shared<SittingPoints>(std::move(geometry->sittingPoints));
+
     QHash<QString, size_t> materialIDAtlas;
-    for (const FBXMaterial& material : _geometry->materials) {
+    for (FBXMaterial& material : geometry->materials) {
         materialIDAtlas[material.materialID] = _materials.size();
-        _materials.push_back(std::make_shared<NetworkMaterial>(material, _textureBaseUrl));
+        _materials.push_back(std::make_shared<NetworkMaterial>(std::move(material), _textureBaseUrl));
     }
 
-    std::shared_ptr<NetworkMeshes> meshes = std::make_shared<NetworkMeshes>();
-    std::shared_ptr<NetworkShapes> shapes = std::make_shared<NetworkShapes>();
+    // Use an intermediate object because _shapes is const.
+    auto shapes = std::make_shared<NetworkShapes>();
     int meshID = 0;
-    for (const FBXMesh& mesh : _geometry->meshes) {
-        // Copy mesh pointers
-        meshes->emplace_back(mesh._mesh);
+    for (const NetworkMesh& mesh : *_meshes) {
         int partID = 0;
         for (const FBXMeshPart& part : mesh.parts) {
             // Construct local shapes
-            shapes->push_back(std::make_shared<NetworkShape>(meshID, partID, (int)materialIDAtlas[part.materialID]));
+            shapes->emplace_back(meshID, partID, (int)materialIDAtlas[part.materialID]);
             partID++;
         }
         meshID++;
     }
-    _meshes = meshes;
     _shapes = shapes;
 
     finishedLoading(true);
@@ -246,8 +248,8 @@ std::shared_ptr<NetworkGeometry> ModelCache::getGeometry(const QUrl& url, const 
     GeometryExtra geometryExtra = { mapping, textureBaseUrl };
     GeometryResource::Pointer resource = getResource(url, QUrl(), true, &geometryExtra).staticCast<GeometryResource>();
     if (resource) {
-        if (resource->isLoaded() && resource->shouldSetTextures()) {
-            resource->setTextures();
+        if (resource->isLoaded()) {
+            resource->resetTextures();
         }
         return std::make_shared<NetworkGeometry>(resource);
     } else {
@@ -258,26 +260,13 @@ std::shared_ptr<NetworkGeometry> ModelCache::getGeometry(const QUrl& url, const 
 const QVariantMap Geometry::getTextures() const {
     QVariantMap textures;
     for (const auto& material : _materials) {
-        for (const auto& texture : material->_textures) {
-            if (texture.texture) {
-                textures[texture.name] = texture.texture->getURL();
-            }
+        auto map = material->getTextures();
+        for (auto texture = map.cbegin(); texture != map.cend(); ++texture) {
+            textures[texture.key()] = texture.value();
         }
     }
 
     return textures;
-}
-
-// FIXME: The materials should only be copied when modified, but the Model currently caches the original
-Geometry::Geometry(const Geometry& geometry) {
-    _geometry = geometry._geometry;
-    _meshes = geometry._meshes;
-    _shapes = geometry._shapes;
-
-    _materials.reserve(geometry._materials.size());
-    for (const auto& material : geometry._materials) {
-        _materials.push_back(std::make_shared<NetworkMaterial>(*material));
-    }
 }
 
 void Geometry::setTextures(const QVariantMap& textureMap) {
@@ -285,19 +274,17 @@ void Geometry::setTextures(const QVariantMap& textureMap) {
         for (auto& material : _materials) {
             // Check if any material textures actually changed
             if (std::any_of(material->_textures.cbegin(), material->_textures.cend(),
-                [&textureMap](const NetworkMaterial::Textures::value_type& it) { return it.texture && textureMap.contains(it.name); })) { 
+                [&textureMap](const std::vector<NetworkMaterial::Texture>::value_type& it) { return it.texture && textureMap.contains(it.name); })) { 
 
-                // FIXME: The Model currently caches the materials (waste of space!)
-                //        so they must be copied in the Geometry copy-ctor
-                // if (material->isOriginal()) {
-                //    // Copy the material to avoid mutating the cached version
-                //    material = std::make_shared<NetworkMaterial>(*material);
-                //}
+                if (material->isCached()) {
+                    // Copy the material to avoid mutating the cached version
+                    material = std::make_shared<NetworkMaterial>(*material);
+                }
 
                 material->setTextures(textureMap);
                 _areTexturesLoaded = false;
 
-                // If we only use cached textures, they should all be loaded
+                // If we only use cached textures, they should all be loaded, so we should check
                 areTexturesLoaded();
             }
         }
@@ -311,7 +298,7 @@ bool Geometry::areTexturesLoaded() const {
         for (auto& material : _materials) {
             // Check if material textures are loaded
             if (std::any_of(material->_textures.cbegin(), material->_textures.cend(),
-                [](const NetworkMaterial::Textures::value_type& it) { return it.texture && !it.texture->isLoaded(); })) {
+                [](const std::vector<NetworkMaterial::Texture>::value_type& it) { return it.texture && !it.texture->isLoaded(); })) {
 
                 return false;
             }
@@ -328,9 +315,9 @@ bool Geometry::areTexturesLoaded() const {
     return true;
 }
 
-const std::shared_ptr<const NetworkMaterial> Geometry::getShapeMaterial(int shapeID) const {
+std::shared_ptr<const NetworkMaterial> Geometry::getShapeMaterial(int shapeID) const {
     if ((shapeID >= 0) && (shapeID < (int)_shapes->size())) {
-        int materialID = _shapes->at(shapeID)->materialID;
+        int materialID = _shapes->at(shapeID).materialID;
         if ((materialID >= 0) && (materialID < (int)_materials.size())) {
             return _materials[materialID];
         }
@@ -339,18 +326,8 @@ const std::shared_ptr<const NetworkMaterial> Geometry::getShapeMaterial(int shap
 }
 
 void GeometryResource::deleter() {
-    resetTextures();
+    releaseTextures();
     Resource::deleter();
-}
-
-void GeometryResource::setTextures() {
-    for (const FBXMaterial& material : _geometry->materials) {
-        _materials.push_back(std::make_shared<NetworkMaterial>(material, _textureBaseUrl));
-    }
-}
-
-void GeometryResource::resetTextures() {
-    _materials.clear();
 }
 
 NetworkGeometry::NetworkGeometry(const GeometryResource::Pointer& networkGeometry) : _resource(networkGeometry) {
@@ -412,14 +389,14 @@ model::TextureMapPointer NetworkMaterial::fetchTextureMap(const QUrl& url, Textu
     return map;
 }
 
-NetworkMaterial::NetworkMaterial(const FBXMaterial& material, const QUrl& textureBaseUrl) :
-    model::Material(*material._material)
+NetworkMaterial::NetworkMaterial(const FBXMaterial&& material, const QUrl& textureBaseUrl) :
+    model::Material(*material._material), _state { std::make_shared<State>() }, _isCached { true }
 {
-    _textures = Textures(MapChannel::NUM_MAP_CHANNELS);
+    _textures = std::vector<Texture>(MapChannel::NUM_MAP_CHANNELS);
     if (!material.albedoTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.albedoTexture, DEFAULT_TEXTURE, MapChannel::ALBEDO_MAP);
-        _albedoTransform = material.albedoTexture.transform;
-        map->setTextureTransform(_albedoTransform);
+        _state->_albedoTransform = material.albedoTexture.transform;
+        map->setTextureTransform(_state->_albedoTransform);
 
         if (!material.opacityTexture.filename.isEmpty()) {
             if (material.albedoTexture.filename == material.opacityTexture.filename) {
@@ -467,17 +444,15 @@ NetworkMaterial::NetworkMaterial(const FBXMaterial& material, const QUrl& textur
 
     if (!material.lightmapTexture.filename.isEmpty()) {
         auto map = fetchTextureMap(textureBaseUrl, material.lightmapTexture, LIGHTMAP_TEXTURE, MapChannel::LIGHTMAP_MAP);
-        _lightmapTransform = material.lightmapTexture.transform;
-        _lightmapParams = material.lightmapParams;
-        map->setTextureTransform(_lightmapTransform);
-        map->setLightmapOffsetScale(_lightmapParams.x, _lightmapParams.y);
+        _state->_lightmapTransform = material.lightmapTexture.transform;
+        _state->_lightmapParams = material.lightmapParams;
+        map->setTextureTransform(_state->_lightmapTransform);
+        map->setLightmapOffsetScale(_state->_lightmapParams.x, _state->_lightmapParams.y);
         setTextureMap(MapChannel::LIGHTMAP_MAP, map);
     }
 }
 
 void NetworkMaterial::setTextures(const QVariantMap& textureMap) {
-    _isOriginal = false;
-
     const auto& albedoName = getTextureName(MapChannel::ALBEDO_MAP);
     const auto& normalName = getTextureName(MapChannel::NORMAL_MAP);
     const auto& roughnessName = getTextureName(MapChannel::ROUGHNESS_MAP);
@@ -489,7 +464,7 @@ void NetworkMaterial::setTextures(const QVariantMap& textureMap) {
     if (!albedoName.isEmpty()) {
         auto url = textureMap.contains(albedoName) ? textureMap[albedoName].toUrl() : QUrl();
         auto map = fetchTextureMap(url, DEFAULT_TEXTURE, MapChannel::ALBEDO_MAP);
-        map->setTextureTransform(_albedoTransform);
+        map->setTextureTransform(_state->_albedoTransform);
         // when reassigning the albedo texture we also check for the alpha channel used as opacity
         map->setUseAlphaChannel(true);
         setTextureMap(MapChannel::ALBEDO_MAP, map);
@@ -530,10 +505,47 @@ void NetworkMaterial::setTextures(const QVariantMap& textureMap) {
     if (!lightmapName.isEmpty()) {
         auto url = textureMap.contains(lightmapName) ? textureMap[lightmapName].toUrl() : QUrl();
         auto map = fetchTextureMap(url, LIGHTMAP_TEXTURE, MapChannel::LIGHTMAP_MAP);
-        map->setTextureTransform(_lightmapTransform);
-        map->setLightmapOffsetScale(_lightmapParams.x, _lightmapParams.y);
+        map->setTextureTransform(_state->_lightmapTransform);
+        map->setLightmapOffsetScale(_state->_lightmapParams.x, _state->_lightmapParams.y);
         setTextureMap(MapChannel::LIGHTMAP_MAP, map);
     }
+
+    if (_state->_originalTextures.isEmpty()) {
+        _state->_originalTextures = getTextures();
+    }
+}
+
+QVariantMap NetworkMaterial::getTextures() const {
+    QVariantMap textures;
+    for (const auto& texture : _textures) {
+        if (texture.texture) {
+            textures[texture.name] = texture.texture->getURL();
+        }
+    }
+    return textures;
+}
+
+void Geometry::releaseTextures() {
+    for (auto& material : _materials) {
+        material->releaseTextures();
+    }
+}
+
+void Geometry::resetTextures() {
+    for (auto& material : _materials) {
+        material->resetTextures();
+    }
+}
+
+void NetworkMaterial::releaseTextures() {
+    for (auto& texture : _textures) {
+        texture.texture.reset();
+    }
+    releaseTextureMaps();
+}
+
+void NetworkMaterial::resetTextures() {
+    setTextures(_state->_originalTextures);
 }
 
 #include "ModelCache.moc"

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -21,14 +21,15 @@
 #include "FBXReader.h"
 #include "TextureCache.h"
 
-// Alias instead of derive to avoid copying
-using NetworkMesh = model::Mesh;
+using NetworkJoint = FBXJoint;
+using NetworkJoints = FBXJoints;
 
-class NetworkTexture;
+using NetworkMesh = FBXMesh;
+using NetworkMeshes = FBXMeshes;
+
 class NetworkMaterial;
-class NetworkShape;
+class NetworkTexture;
 class NetworkGeometry;
-
 class GeometryMappingResource;
 
 /// Stores cached model geometries.
@@ -52,23 +53,67 @@ private:
     virtual ~ModelCache() = default;
 };
 
+/// A material loaded from the network.
+/// Materials include rendering hints (in the key) and textures.
+class NetworkMaterial : public model::Material {
+public:
+    NetworkMaterial(const FBXMaterial&& material, const QUrl& textureBaseUrl);
+
+    QVariantMap getTextures() const;
+
+protected:
+    friend class Geometry;
+
+    using MapChannel = model::Material::MapChannel;
+
+    class Texture {
+    public:
+        QString name;
+        QSharedPointer<NetworkTexture> texture;
+    };
+    std::vector<Texture> _textures;
+
+    void setTextures(const QVariantMap& textureMap);
+
+    static const QString NO_TEXTURE;
+    const QString& getTextureName(MapChannel channel);
+
+    // Textures should not be held while cached; that is for the TextureCache, not the ModelCache.
+    void releaseTextures(); // release textures when caching material
+    void resetTextures(); // reset textures when retrieving material from the cache
+
+    // Materials can be mutated, but the cached version should never be changed.
+    const bool& isCached() const { return _isCached; }
+
+private:
+    // Helpers for the ctors
+    QUrl getTextureUrl(const QUrl& baseUrl, const FBXTexture& fbxTexture);
+    model::TextureMapPointer fetchTextureMap(const QUrl& baseUrl, const FBXTexture& fbxTexture,
+        TextureType type, MapChannel channel);
+    model::TextureMapPointer fetchTextureMap(const QUrl& url, TextureType type, MapChannel channel);
+
+    // State to keep between all instances
+    class State {
+    public:
+        QVariantMap _originalTextures;
+        Transform _albedoTransform;
+        Transform _lightmapTransform;
+        vec2 _lightmapParams;
+    };
+    std::shared_ptr<State> _state;
+
+    bool _isCached { false };
+};
+
+
 class Geometry {
 public:
     using Pointer = std::shared_ptr<Geometry>;
 
-    Geometry() = default;
-    Geometry(const Geometry& geometry);
-
-    // Immutable over lifetime
-    using NetworkMeshes = std::vector<std::shared_ptr<const NetworkMesh>>;
-    using NetworkShapes = std::vector<std::shared_ptr<const NetworkShape>>;
-
-    // Mutable, but must retain structure of vector
-    using NetworkMaterials = std::vector<std::shared_ptr<NetworkMaterial>>;
-
-    const FBXGeometry& getGeometry() const { return *_geometry; }
+    const NetworkJoints& getJoints() const { return *_joints; }
     const NetworkMeshes& getMeshes() const { return *_meshes; }
-    const std::shared_ptr<const NetworkMaterial> getShapeMaterial(int shapeID) const;
+
+    std::shared_ptr<const NetworkMaterial> getShapeMaterial(int shapeID) const;
 
     const QVariantMap getTextures() const;
     void setTextures(const QVariantMap& textureMap);
@@ -78,13 +123,31 @@ public:
 protected:
     friend class GeometryMappingResource;
 
+    using NetworkMaterials = std::vector<std::shared_ptr<NetworkMaterial>>;
+
+    // A map between meshes, parts, and materials.
+    class NetworkShape {
+    public:
+        NetworkShape(int mesh, int part, int material) : meshID { mesh }, partID { part }, materialID { material } {}
+
+        int meshID { -1 };
+        int partID { -1 };
+        int materialID { -1 };
+    };
+    using NetworkShapes = std::vector<NetworkShape>;
+
+
     // Shared across all geometries, constant throughout lifetime
-    std::shared_ptr<const FBXGeometry> _geometry;
+    std::shared_ptr<const NetworkJoints> _joints;
     std::shared_ptr<const NetworkMeshes> _meshes;
     std::shared_ptr<const NetworkShapes> _shapes;
 
     // Copied to each geometry, mutable throughout lifetime via setTextures
     NetworkMaterials _materials;
+
+    // Textures should not be held while cached; that is for the TextureCache, not the ModelCache.
+    void releaseTextures();
+    void resetTextures();
 
 private:
     mutable bool _areTexturesLoaded { false };
@@ -105,12 +168,6 @@ public:
 protected:
     friend class ModelCache;
     friend class GeometryMappingResource;
-
-    // Geometries may not hold onto textures while cached - that is for the texture cache
-    // Instead, these methods clear and reset textures from the geometry when caching/loading
-    bool shouldSetTextures() const { return _geometry && _materials.empty(); }
-    void setTextures();
-    void resetTextures();
 
     QUrl _textureBaseUrl;
 
@@ -142,53 +199,6 @@ private slots:
 private:
     GeometryResource::Pointer _resource;
     Geometry::Pointer _instance { nullptr };
-};
-
-class NetworkMaterial : public model::Material {
-public:
-    using MapChannel = model::Material::MapChannel;
-
-    NetworkMaterial(const FBXMaterial& material, const QUrl& textureBaseUrl);
-
-protected:
-    friend class Geometry;
-
-    class Texture {
-    public:
-        QString name;
-        QSharedPointer<NetworkTexture> texture;
-    };
-    using Textures = std::vector<Texture>;
-
-    Textures _textures;
-
-    static const QString NO_TEXTURE;
-    const QString& getTextureName(MapChannel channel);
-
-    void setTextures(const QVariantMap& textureMap);
-
-    const bool& isOriginal() const { return _isOriginal; }
-
-private:
-    // Helpers for the ctors
-    QUrl getTextureUrl(const QUrl& baseUrl, const FBXTexture& fbxTexture);
-    model::TextureMapPointer fetchTextureMap(const QUrl& baseUrl, const FBXTexture& fbxTexture,
-        TextureType type, MapChannel channel);
-    model::TextureMapPointer fetchTextureMap(const QUrl& url, TextureType type, MapChannel channel);
-
-    Transform _albedoTransform;
-    Transform _lightmapTransform;
-    vec2 _lightmapParams;
-
-    bool _isOriginal { true };
-};
-
-class NetworkShape {
-public:
-    NetworkShape(int mesh, int part, int material) : meshID { mesh }, partID { part }, materialID { material } {}
-    int meshID { -1 };
-    int partID { -1 };
-    int materialID { -1 };
 };
 
 #endif // hifi_ModelCache_h

--- a/libraries/model-networking/src/model-networking/ModelCache.h
+++ b/libraries/model-networking/src/model-networking/ModelCache.h
@@ -109,9 +109,11 @@ private:
 class Geometry {
 public:
     using Pointer = std::shared_ptr<Geometry>;
+    using SittingPoints = QVector<SittingPoint>;
 
     const NetworkJoints& getJoints() const { return *_joints; }
     const NetworkMeshes& getMeshes() const { return *_meshes; }
+    const SittingPoints& getSittingPoints() const { return *_sittingPoints; }
 
     std::shared_ptr<const NetworkMaterial> getShapeMaterial(int shapeID) const;
 
@@ -141,6 +143,7 @@ protected:
     std::shared_ptr<const NetworkJoints> _joints;
     std::shared_ptr<const NetworkMeshes> _meshes;
     std::shared_ptr<const NetworkShapes> _shapes;
+    std::shared_ptr<const SittingPoints> _sittingPoints;
 
     // Copied to each geometry, mutable throughout lifetime via setTextures
     NetworkMaterials _materials;

--- a/libraries/model/src/model/Material.cpp
+++ b/libraries/model/src/model/Material.cpp
@@ -135,6 +135,11 @@ void Material::resetOpacityMap() const {
     _schemaBuffer.edit<Schema>()._key = (uint32)_key._flags.to_ulong();
 }
 
+void Material::releaseTextureMaps() {
+    for (auto& textureMap : _textureMaps) {
+        textureMap.second.reset();
+    }
+}
 
 const TextureMapPointer Material::getTextureMap(MapChannel channel) const {
     auto result = _textureMaps.find(channel);

--- a/libraries/model/src/model/Material.h
+++ b/libraries/model/src/model/Material.h
@@ -298,6 +298,11 @@ public:
     // conversion from legacy material properties to PBR equivalent
     static float shininessToRoughness(float shininess) { return 1.0f - shininess / 100.0f; }
 
+protected:
+    // Textures should not be held while cached; that is for the TextureCache.
+    // This allows NetworkMaterials to release their textures.
+    void releaseTextureMaps();
+
 private:
     mutable MaterialKey _key;
     mutable UniformBufferView _schemaBuffer;

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -321,28 +321,25 @@ ModelMeshPartPayload::ModelMeshPartPayload(Model* model, int _meshIndex, int par
     _shapeID(shapeIndex) {
 
     assert(_model && _model->isLoaded());
-    auto& modelMesh = _model->getGeometry()->getGeometry()->getMeshes().at(_meshIndex);
-    updateMeshPart(modelMesh, partIndex);
+    const auto& mesh = _model->getGeometry()->getMeshes().at(_meshIndex);
+    updateMeshPart(mesh._mesh, partIndex);
 
     updateTransform(transform, offsetTransform);
     initCache();
 }
 
 void ModelMeshPartPayload::initCache() {
-    assert(_model->isLoaded());
-
     if (_drawMesh) {
         auto vertexFormat = _drawMesh->getVertexFormat();
         _hasColorAttrib = vertexFormat->hasAttribute(gpu::Stream::COLOR);
         _isSkinned = vertexFormat->hasAttribute(gpu::Stream::SKIN_CLUSTER_WEIGHT) && vertexFormat->hasAttribute(gpu::Stream::SKIN_CLUSTER_INDEX);
 
-        const FBXGeometry& geometry = _model->getFBXGeometry();
-        const FBXMesh& mesh = geometry.meshes.at(_meshIndex);
+        const auto& mesh = _model->getGeometry()->getMeshes().at(_meshIndex);
 
         _isBlendShaped = !mesh.blendshapes.isEmpty();
     }
 
-    auto networkMaterial = _model->getGeometry()->getGeometry()->getShapeMaterial(_shapeID);
+    auto networkMaterial = _model->getGeometry()->getShapeMaterial(_shapeID);
     if (networkMaterial) {
         _drawMaterial = networkMaterial;
     };
@@ -393,20 +390,18 @@ ItemKey ModelMeshPartPayload::getKey() const {
 }
 
 ShapeKey ModelMeshPartPayload::getShapeKey() const {
-    assert(_model->isLoaded());
-    const FBXGeometry& geometry = _model->getFBXGeometry();
-    const auto& networkMeshes = _model->getGeometry()->getGeometry()->getMeshes();
+    const auto& meshes = _model->getGeometry()->getMeshes();
 
     // guard against partially loaded meshes
-    if (_meshIndex >= (int)networkMeshes.size() || _meshIndex >= (int)geometry.meshes.size() || _meshIndex >= (int)_model->_meshStates.size()) {
+    if (_meshIndex >= (int)meshes.size() || _meshIndex >= (int)_model->_meshStates.size()) {
         return ShapeKey::Builder::invalid();
     }
 
-    const FBXMesh& mesh = geometry.meshes.at(_meshIndex);
+    const FBXMesh& mesh = meshes.at(_meshIndex);
 
     // if our index is ever out of range for either meshes or networkMeshes, then skip it, and set our _meshGroupsKnown
     // to false to rebuild out mesh groups.
-    if (_meshIndex < 0 || _meshIndex >= (int)networkMeshes.size() || _meshIndex > geometry.meshes.size()) {
+    if (_meshIndex < 0 || _meshIndex >= (int)meshes.size()) {
         _model->_meshGroupsKnown = false; // regenerate these lists next time around.
         _model->_readyWhenAdded = false; // in case any of our users are using scenes
         _model->invalidCalculatedMeshBoxes(); // if we have to reload, we need to assume our mesh boxes are all invalid

--- a/libraries/render-utils/src/MeshPartPayload.cpp
+++ b/libraries/render-utils/src/MeshPartPayload.cpp
@@ -397,7 +397,7 @@ ShapeKey ModelMeshPartPayload::getShapeKey() const {
         return ShapeKey::Builder::invalid();
     }
 
-    const FBXMesh& mesh = meshes.at(_meshIndex);
+    const auto& mesh = meshes.at(_meshIndex);
 
     // if our index is ever out of range for either meshes or networkMeshes, then skip it, and set our _meshGroupsKnown
     // to false to rebuild out mesh groups.

--- a/libraries/render-utils/src/Model.cpp
+++ b/libraries/render-utils/src/Model.cpp
@@ -216,7 +216,7 @@ bool Model::updateGeometry() {
     if (_rig->jointStatesEmpty() && getGeometry()->getJoints().size() > 0) {
         initJointStates();
 
-        foreach (const FBXMesh& mesh, getGeometry()->getMeshes()) {
+        foreach (const auto& mesh, getGeometry()->getMeshes()) {
             MeshState state;
             state.clusterMatrices.resize(mesh.clusters.size());
             state.cauterizedClusterMatrices.resize(mesh.clusters.size());
@@ -406,7 +406,7 @@ void Model::recalculateMeshBoxes(bool pickAgainstTriangles) {
         _calculatedMeshTriangles.resize(numberOfMeshes);
         _calculatedMeshPartBoxes.clear();
         for (int i = 0; i < numberOfMeshes; i++) {
-            const FBXMesh& mesh = meshes.at(i);
+            const auto& mesh = meshes.at(i);
             Extents scaledMeshExtents = calculateScaledOffsetExtents(mesh.meshExtents, _translation, _rotation);
 
             _calculatedMeshBoxes[i] = AABox(scaledMeshExtents);
@@ -414,7 +414,7 @@ void Model::recalculateMeshBoxes(bool pickAgainstTriangles) {
             if (pickAgainstTriangles) {
                 QVector<Triangle> thisMeshTriangles;
                 for (int j = 0; j < mesh.parts.size(); j++) {
-                    const FBXMeshPart& part = mesh.parts.at(j);
+                    const auto& part = mesh.parts.at(j);
 
                     bool atLeastOnePointInBounds = false;
                     AABox thisPartBounds;
@@ -511,7 +511,7 @@ void Model::recalculateMeshBoxes(bool pickAgainstTriangles) {
 void Model::renderSetup(RenderArgs* args) {
     // set up dilated textures on first render after load/simulate
     if (_dilatedTextures.isEmpty()) {
-        foreach (const FBXMesh& mesh, getGeometry()->getMeshes()) {
+        foreach (const auto& mesh, getGeometry()->getMeshes()) {
             QVector<QSharedPointer<Texture> > dilated;
             dilated.resize(mesh.parts.size());
             _dilatedTextures.append(dilated);
@@ -876,7 +876,7 @@ void Blender::run() {
     auto geometry = _geometry.lock();
     if (_model && geometry) {
         int offset = 0;
-        foreach (const FBXMesh& mesh, geometry->getGeometry()->getMeshes()) {
+        foreach (const auto& mesh, geometry->getGeometry()->getMeshes()) {
             if (mesh.blendshapes.isEmpty()) {
                 continue;
             }
@@ -893,7 +893,7 @@ void Blender::run() {
                     continue;
                 }
                 float normalCoefficient = vertexCoefficient * NORMAL_COEFFICIENT_SCALE;
-                const FBXBlendshape& blendshape = mesh.blendshapes.at(i);
+                const auto& blendshape = mesh.blendshapes.at(i);
                 for (int j = 0; j < blendshape.indices.size(); j++) {
                     int index = blendshape.indices.at(j);
                     meshVertices[index] += blendshape.vertices.at(j) * vertexCoefficient;
@@ -1048,10 +1048,10 @@ void Model::updateClusterMatrices(glm::vec3 modelPosition, glm::quat modelOrient
     glm::mat4 modelToWorld = glm::mat4_cast(modelOrientation);
     for (int i = 0; i < _meshStates.size(); i++) {
         MeshState& state = _meshStates[i];
-        const FBXMesh& mesh = geometry->getMeshes().at(i);
+        const auto& mesh = geometry->getMeshes().at(i);
 
         for (int j = 0; j < mesh.clusters.size(); j++) {
-            const FBXCluster& cluster = mesh.clusters.at(j);
+            const auto& cluster = mesh.clusters.at(j);
             auto jointMatrix = _rig->getJointTransform(cluster.jointIndex);
             state.clusterMatrices[j] = modelToWorld * jointMatrix * cluster.inverseBindMatrix;
 
@@ -1095,18 +1095,18 @@ void Model::updateClusterMatrices(glm::vec3 modelPosition, glm::quat modelOrient
 }
 
 void Model::inverseKinematics(int endIndex, glm::vec3 targetPosition, const glm::quat& targetRotation, float priority) {
-    const QVector<int>& freeLineage = getGeometry()->getJoints().at(endIndex).freeLineage;
+    const auto& freeLineage = getGeometry()->getJoints().at(endIndex).freeLineage;
     glm::mat4 parentTransform = glm::scale(_scale) * glm::translate(_offset);
     _rig->inverseKinematics(endIndex, targetPosition, targetRotation, priority, freeLineage, parentTransform);
 }
 
 bool Model::restoreJointPosition(int jointIndex, float fraction, float priority) {
-    const QVector<int>& freeLineage = getGeometry()->getJoints().at(jointIndex).freeLineage;
+    const auto& freeLineage = getGeometry()->getJoints().at(jointIndex).freeLineage;
     return _rig->restoreJointPosition(jointIndex, fraction, priority, freeLineage);
 }
 
 float Model::getLimbLength(int jointIndex) const {
-    const QVector<int>& freeLineage = getGeometry()->getJoints().at(jointIndex).freeLineage;
+    const auto& freeLineage = getGeometry()->getJoints().at(jointIndex).freeLineage;
     return _rig->getLimbLength(jointIndex, freeLineage, _scale, getGeometry()->getJoints());
 }
 
@@ -1132,7 +1132,7 @@ void Model::setBlendedVertices(int blendNumber, const std::weak_ptr<NetworkGeome
     const auto& meshes = geometryRef->getGeometry()->getMeshes();
     int index = 0;
     for (int i = 0; i < meshes.size(); i++) {
-        const FBXMesh& mesh = meshes.at(i);
+        const auto& mesh = meshes.at(i);
         if (mesh.blendshapes.isEmpty()) {
             continue;
         }

--- a/libraries/render-utils/src/Model.h
+++ b/libraries/render-utils/src/Model.h
@@ -97,7 +97,7 @@ public:
                     bool showCollisionHull = false);
     void removeFromScene(std::shared_ptr<render::Scene> scene, render::PendingChanges& pendingChanges);
     void renderSetup(RenderArgs* args);
-    bool isRenderable() const { return !_meshStates.isEmpty() || (isActive() && getGeometry()->getGeometry()->getMeshes().empty()); }
+    bool isRenderable() const { return !_meshStates.isEmpty() || (isActive() && !getGeometry()->getMeshes().isEmpty()); }
 
     bool isVisible() const { return _isVisible; }
 
@@ -128,18 +128,12 @@ public:
     virtual void updateClusterMatrices(glm::vec3 modelPosition, glm::quat modelOrientation);
 
     /// Returns a reference to the shared geometry.
-    const NetworkGeometry::Pointer& getGeometry() const { return _geometry; }
+    const Geometry::Pointer& getGeometry() const { assert(isLoaded()); return _geometry->getGeometry(); }
     /// Returns a reference to the shared collision geometry.
-    const NetworkGeometry::Pointer& getCollisionGeometry() const { return _collisionGeometry; }
+    const Geometry::Pointer& getCollisionGeometry() const { assert(isCollisionLoaded()); return _collisionGeometry->getGeometry(); }
 
     const QVariantMap getTextures() const { assert(isLoaded()); return _geometry->getGeometry()->getTextures(); }
     void setTextures(const QVariantMap& textures);
-
-    /// Provided as a convenience, will crash if !isLoaded()
-    // And so that getGeometry() isn't chained everywhere
-    const FBXGeometry& getFBXGeometry() const { assert(isLoaded()); return getGeometry()->getGeometry()->getGeometry(); }
-    /// Provided as a convenience, will crash if !isCollisionLoaded()
-    const FBXGeometry& getCollisionFBXGeometry() const { assert(isCollisionLoaded()); return getCollisionGeometry()->getGeometry()->getGeometry(); }
 
     // Set the model to use for collisions.
     // Should only be called from the model's rendering thread to avoid access violations of changed geometry.

--- a/tools/vhacd-util/src/VHACDUtil.cpp
+++ b/tools/vhacd-util/src/VHACDUtil.cpp
@@ -202,7 +202,7 @@ bool vhacd::VHACDUtil::computeVHACD(FBXGeometry& geometry,
 
     std::cout << "Performing V-HACD computation on " << endMeshIndex - startMeshIndex << " meshes ..... " << std::endl;
 
-    result.meshExtents.reset();
+    result.meshes.meshExtents.reset();
     result.meshes.append(FBXMesh());
     FBXMesh &resultMesh = result.meshes.last();
 


### PR DESCRIPTION
_This is acting as a placeholder until I can properly PR this upstream._
- Move FBX data into the network geometry (don't retain it)
- Construct animations from Joints and AnimationFrames, not entire Geometries
- Change entity tree interface to avoid exposing geometry ptr

---
#### Intent

FBXGeometries are copied to models, but remain around, and are constantly referred to. This uses an unnecessary amount of memory. Instead, this PR moves the data from a FBXGeometry into the model, so it is not kept around.

(See: https://app.asana.com/0/74051501495175/104882336403361.)
#### Testing
- When I say "Note your memory", I am just looking in the task manager.
- I did this twice in each build: once with default cache settings, once with cache sizes set to 0.
1. Go Home (as a starting point) in current build. Note your memory.
2. Go to domains with lots of content (such as Playa or Demo). Load everything without turning around. Note your memory.
3. Go back Home. Note your memory.

_My memory usage, going nimdok->demo->turn off caches and hop around a bit->nimdok->demo.
Note: There appears to be a memory leak, as the memory usage will increase every time you leave and return to a domain, despite cache size. I'm showing the size on my second return trip. This is not related to this PR._

| Build | Cache | Domain | Memory Usage (Mb) |
| --- | --- | --- | --- |
| 4670 | On | demo |  |
| 4670 | Off | demo |  |
| PR | On | demo |  |
| PR | Off | demo |  |
| 4670 | On | hell |  |
| 4670 | Off | hell |  |
| PR | On | hell |  |
| PR | Off | hell |  |

Make sure multiple instances of the same model can still have different textures assigned to them.
Make sure when going across domains, caching still works correctly.
Outside of this, general smoke test.
